### PR TITLE
Allow the generator to work with any collection type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ bin-release/
 
 # Other files and folders
 .settings/
+.build/
+
+# macOS
+.DS_Store
 
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,7 @@
+// swift-tools-version:3.1
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftProductGenerator"
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,14 @@
-// swift-tools-version:3.1
+// swift-tools-version:4.0
 
 import PackageDescription
 
 let package = Package(
-    name: "SwiftProductGenerator"
+    name: "SwiftProductGenerator",
+    targets: [
+        .target(
+            name: "SwiftProductGenerator"),
+        .testTarget(
+            name: "SwiftProductGeneratorTests",
+            dependencies: ["SwiftProductGenerator"]),
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftProductGenerator",
+    products: [
+       .library(name: "SwiftProductGenerator", targets: ["SwiftProductGenerator"])
+    ],
     targets: [
         .target(
             name: "SwiftProductGenerator"),

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # SwiftProductGenerator
-A generic cartesian product generator written in swift
-
-Similar to Python's itertools.Product
+A generic cartesian product generator written in swift similar to Python's [`itertools.Product`](https://docs.python.org/3/library/itertools.html).
 
 ## Mission
-Reduce memory consumption and processing time for cartesian product of arbitrary arrays
+Reduce memory consumption and processing time for cartesian product of arbitrary arrays.
 
 
 ## Usage
-The generator is initialized with an array containing the arrays to be combined:
+The generator is initialized with an array containing the collections to be combined:
 ```swift
 let arrays = [
   [0,1],
@@ -21,7 +19,7 @@ let generator = product(arrays)
 
 An equivalent statement would be:
 ```swift
-let generator = product([0,1], repeat: 3)
+let generator = product(repeating: [0,1], count: 3)
 ```
 
 The generator from the examples will generate this array lazily
@@ -37,5 +35,3 @@ The generator from the examples will generate this array lazily
   [1, 1, 1]
 ]
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 A generic cartesian product generator written in swift similar to Python's [`itertools.Product`](https://docs.python.org/3/library/itertools.html).
 
 ## Mission
-Reduce memory consumption and processing time for cartesian product of arbitrary arrays.
-
+Reduce memory consumption and processing time for cartesian product of arbitrary collections.
 
 ## Usage
 The generator is initialized with an array containing the collections to be combined:

--- a/Sources/SwiftProductGenerator.swift
+++ b/Sources/SwiftProductGenerator.swift
@@ -13,7 +13,7 @@ A cartesian product generator
 :discussion:    Generates the cartesian product of arrays, or repetitions of an array. The rightmost element is advanced every iteration which ensures that if the input is sorted, the output will be sorted as well.
 */
 
-public struct product<T>: IteratorProtocol, Sequence {
+public struct Product<T>: IteratorProtocol, Sequence {
 
     /// Private variable to manage where to get next element in each pool
     private var indices : [Int]
@@ -106,7 +106,7 @@ public struct product<T>: IteratorProtocol, Sequence {
 
     :returns:       A cartesian product generator
     */
-    public func generate() -> product {
+    public func generate() -> Product {
         return self
     }
 }

--- a/Sources/SwiftProductGenerator.swift
+++ b/Sources/SwiftProductGenerator.swift
@@ -10,101 +10,98 @@
 /**
 A cartesian product generator
 
-:discussion:    Generates the cartesian product of arrays, or repetitions of an array. The rightmost element is advanced every iteration which ensures that if the input is sorted, the output will be sorted as well.
+:discussion:    Generates the cartesian product of collections, or repetitions
+                of a collection. The rightmost element is advanced every
+                iteration which ensures that if the input is sorted, the
+                output will be sorted as well.
 */
-
-public struct Product<T>: IteratorProtocol, Sequence {
+public struct Product<T, C: Collection>: IteratorProtocol, Sequence
+    where C.Iterator.Element == T
+{
 
     /// Private variable to manage where to get next element in each pool
-    private var indices : [Int]
-    /// Pool containing all the arrays to be combined
-    private var pools : [[T]]
+    private var indices : [C.Index]
+    /// Pool containing all the collections to be combined
+    private var pools   : [C]
     /// Terminate the generation on completion
-    private var done : Bool = false
+    private var done    : Bool = false
 
 
     /**
-    Initiates the generator with an array of arrays to be combined
+    Initiates the generator with an array of collections to be combined.
 
-    :param:     arrays  array containing arrays to be combined
+    :param:        collections    array containing the collections to be
+                                  combined
+    */
+    public init(_ collections: [C]) {
+        self.pools   = collections
+        self.indices = collections.map{ $0.startIndex }
+        self.done    = pools.reduce(true, { $0 && $1.count == 0 })
+    }
 
-    :returns:   An array containing the products of the provided arrays
+    /**
+    Initiates the generator with a collection repeated 'count' times.
+
+    :param:        repeating      collection to be combined with itself
+    :param:        count          number of times to repeat the collection
     */
 
-    public init(_ arrays: [[T]]) {
-
-        self.pools = arrays
-        self.indices = [Int](repeating: 0, count: self.pools.count)
-        self.done = pools.filter({$0.count == 0}).count != 0
+    public init(repeating collection: C, count: Int) {
+        precondition(count >= 0, "count must be >= 0")
+        self.init([C](repeating: collection, count: count))
     }
 
 
     /**
-    Initiates the generator with an array repeated 'repeat' times
-
-    :param:     array   array containing elements to be combined
-    :param:     repeat  number of elements in product
-
-    :returns:   An array containing the products of the provided array repeated 'repeat' times
+    Generates the next element and returns it.
     */
-
-    public init(_ array: [T], repeats: Int) {
-        assert(repeats >= 0, "repeats must be >= 0")
-
-        self.pools = [[T]](repeating: array, count: repeats)
-        self.indices = [Int](repeating: 0, count: self.pools.count)
-        self.done = repeats <= 0 && pools.filter({$0.count == 0}).count != 0
-    }
-
-
-    /**
-    Generate the next element and return it
-
-    :returns:   An optional element
-    */
-
     public mutating func next() -> [T]? {
         if done {
             return nil
         }
 
-        let element = pools.enumerated().map {
+        let element = self.pools.enumerated().map {
             $1[ self.indices[$0] ]
         }
 
-        self.incrementLocationInPool(poolIndex: self.pools.count-1)
+        self.incrementLocationInPool(poolIndex: self.pools.count - 1)
         return element
     }
 
 
     /**
-    Initiates the generator with an array of arrays to be combined
+    Increments the indices of the collections in the pools.
 
-    :discussion:    The location in the pool for the provided 'poolIndex' will be incremented. If the new location is out of range, the location is set to zero and the location in the preceding pool will be incremented. If 'poolIndex' is less than zero, the generation is complete.
+    :discussion:   The location in the pool for the provided 'poolIndex' will
+                   be incremented. If the new location is out of range, the
+                   location is set to zero and the location in the preceding
+                   pool will be incremented. If 'poolIndex' is less than zero,
+                   the generation is complete.
 
-    :param:         poolIndex   index of the pool for which to update the location
+    :param:        poolIndex      index of the pool for which to update the
+                                  location
 
-    :returns:       An array containing the products of the provided array repeated 'repeat' times
+    :returns:      An array containing the products of the provided array
+                   repeated 'repeat' times
     */
-
     mutating private func incrementLocationInPool(poolIndex: Int) {
         if poolIndex < 0 {
             return done = true
         }
 
-        indices[poolIndex] += 1
+        self.indices[poolIndex] = self.pools[poolIndex].index(after: self.indices[poolIndex])
 
-        if indices[poolIndex] == pools[poolIndex].count {
-            indices[poolIndex] = 0
-            incrementLocationInPool(poolIndex: poolIndex-1)
+        if self.indices[poolIndex] == self.pools[poolIndex].endIndex {
+            self.indices[poolIndex] = self.pools[poolIndex].startIndex
+            self.incrementLocationInPool(poolIndex: poolIndex - 1)
         }
     }
 
 
     /**
-    Returns a cartesian product generator
+    Returns a cartesian product generator.
 
-    :returns:       A cartesian product generator
+    :returns:      A cartesian product generator
     */
     public func generate() -> Product {
         return self

--- a/Sources/SwiftProductGenerator/SwiftProductGenerator.swift
+++ b/Sources/SwiftProductGenerator/SwiftProductGenerator.swift
@@ -85,8 +85,9 @@ public struct Product<T, C: Collection>: IteratorProtocol, Sequence
                    repeated 'repeat' times
     */
     mutating private func incrementLocationInPool(poolIndex: Int) {
-        if poolIndex < 0 {
-            return done = true
+        guard self.pools.indices.contains(poolIndex) else {
+            done = true
+            return
         }
 
         self.indices[poolIndex] = self.pools[poolIndex].index(after: self.indices[poolIndex])

--- a/SwiftProductGenerator.swift
+++ b/SwiftProductGenerator.swift
@@ -1,12 +1,10 @@
 //
 //  SwiftProductGenerator.swift
-//  
+//
 //
 //  Created by Øyvind Grimnes on 09/09/15.
 //
 //
-
-import Foundation
 
 
 /**
@@ -15,97 +13,97 @@ A cartesian product generator
 :discussion:    Generates the cartesian product of arrays, or repetitions of an array. The rightmost element is advanced every iteration which ensures that if the input is sorted, the output will be sorted as well.
 */
 
-public struct product<T>: GeneratorType, SequenceType {
-    
+public struct product<T>: IteratorProtocol, Sequence {
+
     /// Private variable to manage where to get next element in each pool
     private var indices : [Int]
     /// Pool containing all the arrays to be combined
     private var pools : [[T]]
     /// Terminate the generation on completion
     private var done : Bool = false
-    
-    
+
+
     /**
     Initiates the generator with an array of arrays to be combined
-    
+
     :param:     arrays  array containing arrays to be combined
-    
+
     :returns:   An array containing the products of the provided arrays
     */
-    
+
     public init(_ arrays: [[T]]) {
 
         self.pools = arrays
-        self.indices = [Int](count: self.pools.count, repeatedValue: 0)
+        self.indices = [Int](repeating: 0, count: self.pools.count)
         self.done = pools.filter({$0.count == 0}).count != 0
     }
 
-    
+
     /**
     Initiates the generator with an array repeated 'repeat' times
-    
+
     :param:     array   array containing elements to be combined
     :param:     repeat  number of elements in product
-    
+
     :returns:   An array containing the products of the provided array repeated 'repeat' times
     */
-    
+
     public init(_ array: [T], repeats: Int) {
         assert(repeats >= 0, "repeats must be >= 0")
-        
-        self.pools = [[T]](count: repeats, repeatedValue: array)
-        self.indices = [Int](count: self.pools.count, repeatedValue: 0)
+
+        self.pools = [[T]](repeating: array, count: repeats)
+        self.indices = [Int](repeating: 0, count: self.pools.count)
         self.done = repeats <= 0 && pools.filter({$0.count == 0}).count != 0
     }
-    
-    
+
+
     /**
     Generate the next element and return it
-    
+
     :returns:   An optional element
     */
-    
+
     public mutating func next() -> [T]? {
         if done {
             return nil
         }
 
-        let element = pools.enumerate().map {
+        let element = pools.enumerated().map {
             $1[ self.indices[$0] ]
         }
-        
-        self.incrementLocationInPool(self.pools.count-1)
+
+        self.incrementLocationInPool(poolIndex: self.pools.count-1)
         return element
     }
-    
-    
+
+
     /**
     Initiates the generator with an array of arrays to be combined
-    
+
     :discussion:    The location in the pool for the provided 'poolIndex' will be incremented. If the new location is out of range, the location is set to zero and the location in the preceding pool will be incremented. If 'poolIndex' is less than zero, the generation is complete.
-    
+
     :param:         poolIndex   index of the pool for which to update the location
-    
+
     :returns:       An array containing the products of the provided array repeated 'repeat' times
     */
-    
+
     mutating private func incrementLocationInPool(poolIndex: Int) {
         if poolIndex < 0 {
             return done = true
         }
-        
-        indices[poolIndex]++
-        
+
+        indices[poolIndex] += 1
+
         if indices[poolIndex] == pools[poolIndex].count {
             indices[poolIndex] = 0
-            incrementLocationInPool(poolIndex-1)
+            incrementLocationInPool(poolIndex: poolIndex-1)
         }
     }
-    
-    
+
+
     /**
     Returns a cartesian product generator
-    
+
     :returns:       A cartesian product generator
     */
     public func generate() -> product {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import SwiftProductGeneratorTests
+
+XCTMain([
+    testCase(SwiftProductGeneratorTests.allTests),
+])

--- a/Tests/SwiftProductGeneratorTests/SwiftProductGeneratorTests.swift
+++ b/Tests/SwiftProductGeneratorTests/SwiftProductGeneratorTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 class SwiftProductGeneratorTests: XCTestCase {
     func testEmptySet() {
-        let gen = Product<Int>([])
+        let gen = Product<Int, [Int]>([])
         let res = gen.map{ $0 }
-        XCTAssertTrue(res[0].isEmpty)
+        XCTAssertTrue(res.isEmpty)
     }
 
     func testSingleton() {
@@ -44,10 +44,26 @@ class SwiftProductGeneratorTests: XCTestCase {
         XCTAssertTrue(res.contains{ $0 == [1,2,3] })
     }
 
+    func testRepeatingInitializer() {
+        let gen = Product(repeating: [0,1], count: 3)
+        let res = gen.map{ $0 }
+
+        XCTAssertEqual(res.count, 8)
+        XCTAssertTrue(res.contains{ $0 == [0,0,0] })
+        XCTAssertTrue(res.contains{ $0 == [0,0,1] })
+        XCTAssertTrue(res.contains{ $0 == [0,1,0] })
+        XCTAssertTrue(res.contains{ $0 == [0,1,1] })
+        XCTAssertTrue(res.contains{ $0 == [1,0,0] })
+        XCTAssertTrue(res.contains{ $0 == [1,0,1] })
+        XCTAssertTrue(res.contains{ $0 == [1,1,0] })
+        XCTAssertTrue(res.contains{ $0 == [1,1,1] })
+    }
+
     static var allTests = [
-        ("testEmptySet" , testEmptySet),
-        ("testSingleton", testEmptySet),
-        ("testPair"     , testEmptySet),
-        ("testTriple"   , testEmptySet),
+        ("testEmptySet"            , testEmptySet),
+        ("testSingleton"           , testEmptySet),
+        ("testPair"                , testEmptySet),
+        ("testTriple"              , testEmptySet),
+        ("testRepeatingInitializer", testRepeatingInitializer),
     ]
 }

--- a/Tests/SwiftProductGeneratorTests/SwiftProductGeneratorTests.swift
+++ b/Tests/SwiftProductGeneratorTests/SwiftProductGeneratorTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import SwiftProductGenerator
+
+class SwiftProductGeneratorTests: XCTestCase {
+    func testEmptySet() {
+        let gen = Product<Int>([])
+        let res = gen.map{ $0 }
+        XCTAssertTrue(res[0].isEmpty)
+    }
+
+    func testSingleton() {
+        let gen = Product([[0,1,2]])
+        let res = gen.map{ $0 }
+
+        XCTAssertEqual(res.count, 3)
+        XCTAssertTrue(res.contains{ $0 == [0] })
+        XCTAssertTrue(res.contains{ $0 == [1] })
+        XCTAssertTrue(res.contains{ $0 == [2] })
+    }
+
+    func testPair() {
+        let gen = Product([[0,1], [1,2]])
+        let res = gen.map{ $0 }
+
+        XCTAssertEqual(res.count, 4)
+        XCTAssertTrue(res.contains{ $0 == [0,1] })
+        XCTAssertTrue(res.contains{ $0 == [0,2] })
+        XCTAssertTrue(res.contains{ $0 == [1,1] })
+        XCTAssertTrue(res.contains{ $0 == [1,2] })
+    }
+
+    func testTriple() {
+        let gen = Product([[0,1], [1,2], [2,3]])
+        let res = gen.map{ $0 }
+
+        XCTAssertEqual(res.count, 8)
+        XCTAssertTrue(res.contains{ $0 == [0,1,2] })
+        XCTAssertTrue(res.contains{ $0 == [0,1,3] })
+        XCTAssertTrue(res.contains{ $0 == [0,2,2] })
+        XCTAssertTrue(res.contains{ $0 == [0,2,3] })
+        XCTAssertTrue(res.contains{ $0 == [1,1,2] })
+        XCTAssertTrue(res.contains{ $0 == [1,1,3] })
+        XCTAssertTrue(res.contains{ $0 == [1,2,2] })
+        XCTAssertTrue(res.contains{ $0 == [1,2,3] })
+    }
+
+    static var allTests = [
+        ("testEmptySet" , testEmptySet),
+        ("testSingleton", testEmptySet),
+        ("testPair"     , testEmptySet),
+        ("testTriple"   , testEmptySet),
+    ]
+}


### PR DESCRIPTION
This pull requests makes the product generator generic to the type of the collection used as argument of the cartesian product. As a result, it is possible to use other types than arrays (for instance sets or dictionaries from the standard library).

It also ports the code to Swift 3.
